### PR TITLE
Validate DS18B20 CRC

### DIFF
--- a/STM32CubeExpansion_LRWAN/Drivers/BSP/Components/ds18b20/ds18b20.h
+++ b/STM32CubeExpansion_LRWAN/Drivers/BSP/Components/ds18b20/ds18b20.h
@@ -89,7 +89,7 @@ uint8_t DS18B20_ReadByte(uint8_t num);
 void DS18B20_WriteBit(uint8_t dat,uint8_t num);
 void DS18B20_WriteByte(uint8_t dat,uint8_t num);
 void DS18B20_SkipRom(uint8_t num);
-float DS18B20_GetTemp_SkipRom (uint8_t num);
+float DS18B20_GetTemp_SkipRom (uint8_t num, bool *success);
 #ifdef __cplusplus
 }
 #endif

--- a/STM32CubeExpansion_LRWAN/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/inc/bsp.h
+++ b/STM32CubeExpansion_LRWAN/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/inc/bsp.h
@@ -66,6 +66,8 @@ Maintainer: Miguel Luis and Gregory Cristian
  extern "C" {
 #endif
 /* Includes ------------------------------------------------------------------*/
+#include <stdbool.h>
+
 /* Exported types ------------------------------------------------------------*/
 
 typedef struct{
@@ -73,10 +75,13 @@ typedef struct{
   int   in1;/*GPIO Digital Input 0 or 1*/
 	
 	float temp1;//DS18B20-1
+	bool temp1_ok;//DS18B20-1
 
 	float temp2;//DS18B20-2
+	bool temp2_ok;//DS18B20-2
 
 	float temp3;//DS18B20-3
+	bool temp3_ok;//DS18B20-3
 	
 	float oil;  //oil float
 

--- a/STM32CubeExpansion_LRWAN/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/bsp.c
+++ b/STM32CubeExpansion_LRWAN/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/bsp.c
@@ -130,7 +130,7 @@ void BSP_sensor_Read( sensor_t *sensor_data)
 	
 	sensor_data->in1=HAL_GPIO_ReadPin(GPIO_INPUT_PORT,GPIO_INPUT_PIN1);
 
-	sensor_data->temp1=DS18B20_GetTemp_SkipRom(1);
+	sensor_data->temp1=DS18B20_GetTemp_SkipRom(1, &sensor_data->temp1_ok);
 	
 	 if((mode==1)||(mode==3))
 	 {		
@@ -197,8 +197,8 @@ void BSP_sensor_Read( sensor_t *sensor_data)
 
    else if(mode==4)
    {
-		sensor_data->temp2=DS18B20_GetTemp_SkipRom(2);
-		sensor_data->temp3=DS18B20_GetTemp_SkipRom(3);	 
+		sensor_data->temp2=DS18B20_GetTemp_SkipRom(2, &sensor_data->temp2_ok);
+		sensor_data->temp3=DS18B20_GetTemp_SkipRom(3, &sensor_data->temp3_ok);	 
 	 }	
 	 
 	 else if(mode==5)

--- a/STM32CubeExpansion_LRWAN/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/main.c
+++ b/STM32CubeExpansion_LRWAN/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/main.c
@@ -438,10 +438,13 @@ static void Send( void )
 	{		
 		AppData.Buff[i++] =(batteryLevel_mV>>8);       //level of battery in mV
 		AppData.Buff[i++] =batteryLevel_mV & 0xFF;
-	
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10);
-	
+		if(sensor_data.temp1_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
 		AppData.Buff[i++] =(int)(sensor_data.oil)>>8;          //oil float
 		AppData.Buff[i++] =(int)sensor_data.oil;
 
@@ -479,8 +482,13 @@ static void Send( void )
 		AppData.Buff[i++] =(batteryLevel_mV>>8);       //level of battery in mV
 		AppData.Buff[i++] =batteryLevel_mV & 0xFF;
 	
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		if(sensor_data.temp1_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
 	
 		AppData.Buff[i++] =(int)(sensor_data.oil)>>8;          //oil float
 		AppData.Buff[i++] =(int)sensor_data.oil;
@@ -556,8 +564,13 @@ static void Send( void )
 		AppData.Buff[i++] =(batteryLevel_mV>>8);       //level of battery in mV
 		AppData.Buff[i++] =batteryLevel_mV & 0xFF;
 	
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		if(sensor_data.temp1_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
 	
 		AppData.Buff[i++] =(int)(sensor_data.oil)>>8;          //oil float
 		AppData.Buff[i++] =(int)sensor_data.oil;
@@ -572,11 +585,20 @@ static void Send( void )
 			switch_status=HAL_GPIO_ReadPin(GPIO_EXTI_PORT,GPIO_EXTI_PIN);				
 			AppData.Buff[i++]=(switch_status<<7)|(sensor_data.in1<<1)|0x0C;
 		}
-
-		AppData.Buff[i++]=(int)(sensor_data.temp2*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp2*10);
-		AppData.Buff[i++]=(int)(sensor_data.temp3*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp3*10);
+		if(sensor_data.temp2_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp2*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp2*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
+		if(sensor_data.temp3_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp3*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp3*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
 	
 	}	
 	
@@ -584,9 +606,13 @@ static void Send( void )
 	{
 		AppData.Buff[i++] =(batteryLevel_mV>>8);       //level of battery in mV
 		AppData.Buff[i++] =batteryLevel_mV & 0xFF;
-	
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		if(sensor_data.temp1_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
 	
 		AppData.Buff[i++] =(int)(sensor_data.oil)>>8;          //oil float
 		AppData.Buff[i++] =(int)sensor_data.oil;
@@ -613,8 +639,13 @@ static void Send( void )
 		AppData.Buff[i++] =(batteryLevel_mV>>8);       //level of battery in mV
 		AppData.Buff[i++] =batteryLevel_mV & 0xFF;
 		
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
-		AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		if(sensor_data.temp1_ok){
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10)>>8;     //DS18B20
+			AppData.Buff[i++]=(int)(sensor_data.temp1*10);
+		}else{
+			AppData.Buff[i++]=0x80;
+			AppData.Buff[i++]=0x00;
+		}
 	
 		AppData.Buff[i++] =(int)(sensor_data.oil)>>8;          //oil float
 		AppData.Buff[i++] =(int)sensor_data.oil;


### PR DESCRIPTION
This solves #13 by reading the complete scratchpad and validating the CRC at the end of it. When the device is not connected, every call to `DS18B20_ReadByte` will yield `0xFF`, so the CRC will not match.
This is then used to send the bytes `0x80`, `0x00` as the temperature value, which equates to a value far outside of realistic temperatures (far below absolute zero). This makes it easy to determine whether a reading is correct or not.